### PR TITLE
add ovis-hpc build

### DIFF
--- a/ovis-hpc/Dockerfile
+++ b/ovis-hpc/Dockerfile
@@ -1,5 +1,5 @@
 ARG tag=latest
-FROM ubuntu${tag}
+FROM ubuntu:${tag}
 
 # docker build -t test .
 # docker run -itd --name test test 

--- a/ovis-hpc/Dockerfile
+++ b/ovis-hpc/Dockerfile
@@ -1,0 +1,55 @@
+ARG tag=latest
+FROM ubuntu${tag}
+
+# docker build -t test .
+# docker run -itd --name test test 
+# docker exec -it test bash
+
+# Without -a munge because we've disabled auth
+# ldms_ls -h localhost -x sock -p 10444
+# ldms_ls -h localhost -x sock -p 10444 -v
+# ldms_ls -h localhost -x sock -p 10444​ -l
+# ldms_ls -h localhost -x sock -p 10444​ -l -v
+
+
+# This container is intended for testing the fusion fileystem as an application.
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    autogen \
+    bison \
+    build-essential \
+    doxygen \
+    gcc g++ \
+    flex \ 
+    gettext \
+    libtool \
+    libreadline-dev \
+    libevent-dev \
+    libssl-dev \
+    libtool \
+    openssl \
+    pkg-config \
+    swig \
+    systemctl \
+    python3-yaml \
+    python3 \
+    python3-dev \
+    libglib2.0-dev \
+    git \
+    munge
+
+WORKDIR /opt
+RUN git clone https://github.com/ovis-hpc/ovis && \
+    cd ovis && \
+    ./autogen.sh && \
+    ./configure --prefix=/usr && make && make install
+
+ENV LDMSD_PLUGIN_LIBPATH=/usr/lib/ovis-ldms
+ENV ZAP_LIBPATH=/usr/lib/ovis-ldms
+ENV COMPONENT_ID=1
+ENV SAMPLE_INTERVAL=1000000
+ENV SAMPLE_OFFSET=50000
+COPY ./sampler.conf /opt/sampler.conf
+
+COPY ./entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/ovis-hpc/entrypoint.sh
+++ b/ovis-hpc/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Setup munge
+mkdir -p /run/munge
+chown -R 0 /var/log/munge /var/lib/munge /etc/munge /run/munge
+
+
+# Skip munge for now, not on a cluster
+# ldmsd -x sock:10444 -c /opt/sampler.conf -l /tmp/demo_ldmsd_log -v DEBUG -a munge  -r $(pwd)/ldmsd.pid
+ldmsd -x sock:10444 -c /opt/sampler.conf -l /tmp/demo_ldmsd_log -v DEBUG -r $(pwd)/ldmsd.pid
+sleep infinity

--- a/ovis-hpc/sampler.conf
+++ b/ovis-hpc/sampler.conf
@@ -1,0 +1,7 @@
+load name=meminfo
+config name=meminfo producer=${HOSTNAME} instance=${HOSTNAME}/meminfo component_id=${COMPONENT_ID} schema=meminfo job_set=${HOSTNAME}/jobinfo uid=12345 gid=12345 perm=0755
+start name=meminfo interval=${SAMPLE_INTERVAL} offset=${SAMPLE_OFFSET}
+#
+load name=vmstat
+config name=vmstat producer=${HOSTNAME} instance=${HOSTNAME}/vmstat component_id=${COMPONENT_ID} schema=vmstat job_set=${HOSTNAME}/jobinfo uid=0 gid=0 perm=0755
+start name=vmstat interval=${SAMPLE_INTERVAL} offset=${SAMPLE_OFFSET}

--- a/ovis-hpc/uptodate.yaml
+++ b/ovis-hpc/uptodate.yaml
@@ -1,0 +1,7 @@
+dockerbuild:
+
+  build_args:
+    tag:
+      key: tag
+      versions:
+       - latest


### PR DESCRIPTION
this seems to work with the basic sampler config,
and likely we can tweak this on the fly with a config map in kubernetes if/when I learn more detail about how it works!